### PR TITLE
add android o support guide to  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Implement at in your  `Application` class.
       super.onTerminate()
     }
 ```
+If you want support Android O,you can use WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY flag.
 
 ## snapshot
 observe not per Activity, use `TrafficMonitor.snap`.


### PR DESCRIPTION
if you want to support Android O,you can change WindowManager.LayoutParams.Type .
[android-8.0-changes](https://developer.android.com/about/versions/oreo/android-8.0-changes.html#o-apps)
[WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#TYPE_APPLICATION_OVERLAY)
I just change README that it's a troublesome work to change the build version.